### PR TITLE
feat: add Windows support with cmd and UTF-8 encoding

### DIFF
--- a/src/core/agent.ts
+++ b/src/core/agent.ts
@@ -28,13 +28,15 @@ const anthropic = new Anthropic({
 // ---------- System prompt ----------
 const SYSTEM = (
     `You are a coding agent operating INSIDE the user's repository at ${WORKDIR}.\n` +
+    `Operating System: ${process.platform === 'win32' ? 'Windows' : process.platform === 'darwin' ? 'macOS' : 'Linux'}\n` +
+    `Shell: ${process.platform === 'win32' ? 'PowerShell' : 'bash'}\n` +
     "Follow this loop strictly: plan briefly → use TOOLS to act directly on files/shell → report concise results.\n" +
     "Rules:\n" +
     "- Prefer taking actions with tools (read/write/edit/bash) over long prose.\n" +
     "- Keep outputs terse. Use bullet lists / checklists when summarizing.\n" +
     "- Never invent file paths. Ask via reads or list directories first if unsure.\n" +
     "- For edits, apply the smallest change that satisfies the request.\n" +
-    "- For bash, avoid destructive or privileged commands; stay inside the workspace.\n" +
+    "- For bash tool: On Windows use PowerShell syntax, on Unix use bash syntax. Avoid destructive or privileged commands; stay inside the workspace.\n" +
     "- Use the TodoWrite tool to maintain multi-step plans when needed.\n" +
     "- After finishing, summarize what changed and how to run or test.\n" 
 );

--- a/src/index.ts
+++ b/src/index.ts
@@ -10,6 +10,16 @@ import { executeManualCompact, getContextStats } from './utils/context-compressi
 import { TODO_BOARD } from './core/todo-manager';
 import { readFileSync } from 'fs';
 import { join } from 'path';
+import { execSync } from 'child_process';
+
+// Fix Windows console encoding to support UTF-8
+if (process.platform === 'win32') {
+    try {
+        execSync('chcp 65001', { stdio: 'ignore' });
+    } catch {
+        // Ignore encoding setup errors
+    }
+}
 
 async function main() {
     // Load package version

--- a/src/tools/bash.ts
+++ b/src/tools/bash.ts
@@ -2,31 +2,36 @@ import { execSync } from 'child_process';
 import { clampText } from '../utils/text-helpers';
 import { WORKDIR } from '../config/environment';
 
+const DANGEROUS_PATTERNS = {
+    win32: ['format ', 'del /s', 'rmdir /s', 'rd /s', 'shutdown', 'restart-computer', 
+            'remove-item -recurse', 'rm -recurse', 'diskpart', 'reg delete'],
+    unix: ['rm -rf /', 'rm -rf /*', 'shutdown', 'reboot', 'mkfs', 'dd if=', 'sudo ']
+};
+
+function isDangerousCommand(cmd: string): boolean {
+    const patterns = process.platform === 'win32' ? DANGEROUS_PATTERNS.win32 : DANGEROUS_PATTERNS.unix;
+    return patterns.some(p => cmd.toLowerCase().includes(p));
+}
+
 export function runBash(inputObj: any): string {
     const cmd = inputObj.command || "";
-    if (!cmd) {
-        throw new Error("missing bash.command");
-    }
+    if (!cmd) throw new Error("missing bash.command");
+    if (isDangerousCommand(cmd)) throw new Error("blocked dangerous command");
 
-    // Block dangerous commands
-    if (cmd.includes("rm -rf /") || cmd.includes("shutdown") ||
-        cmd.includes("reboot") || cmd.includes("sudo ")) {
-        throw new Error("blocked dangerous command");
-    }
-
-    const timeoutMs = inputObj.timeout_ms || 30000;
-
+    const isWindows = process.platform === 'win32';
+    
     try {
         const result = execSync(cmd, {
             cwd: WORKDIR,
-            timeout: timeoutMs,
-            encoding: 'utf-8'
+            timeout: inputObj.timeout_ms || 30000,
+            encoding: 'utf-8',
+            shell: isWindows ? 'powershell.exe' : undefined,
+            windowsHide: true
         });
         return clampText(result.trim() || "(no output)");
     } catch (error: any) {
-        if (error.signal === 'SIGTERM') {
-            return "(timeout)";
-        }
-        return clampText(error.message || "(error)");
+        if (error.signal === 'SIGTERM') return "(timeout)";
+        const msg = error.stderr?.toString() || error.stdout?.toString() || error.message || "(error)";
+        return clampText(msg);
     }
 }

--- a/src/tools/tools.ts
+++ b/src/tools/tools.ts
@@ -54,14 +54,16 @@ export const baseTools: Anthropic.Tool[] = [
     {
         name: "bash",
         description: (
-            "Execute a shell command inside the project workspace. Use for scaffolding, " +
-            "formatting, running scripts, etc."
+            "Execute a shell command inside the project workspace. " +
+            "On Windows, uses PowerShell by default. On Unix-like systems (Linux, macOS), uses bash. " +
+            "Use for scaffolding, formatting, running scripts, installing packages, etc. " +
+            "Note: Dangerous commands (like format, rm -rf /, shutdown) are blocked for safety."
         ),
         input_schema: {
             type: "object",
             properties: {
-                command: { type: "string", description: "Shell command to run" },
-                timeout_ms: { type: "integer", minimum: 1000, maximum: 120000 },
+                command: { type: "string", description: "Shell command to run (PowerShell on Windows, bash on Unix-like)" },
+                timeout_ms: { type: "integer", minimum: 1000, maximum: 120000, description: "Command timeout in milliseconds (default: 30000)" },
             },
             required: ["command"],
             additionalProperties: false,


### PR DESCRIPTION
## Changes
- Fix Windows console encoding issues (set UTF-8 code page)
- Add cmd support for Windows (bash tool auto-detects platform)
- Add platform-specific dangerous command detection
- Update system prompt with OS/shell information

## Testing
Tested on Windows 11 with cmd

## Compatibility
Backward compatible with Linux/macOS